### PR TITLE
Makes `name` and `schema` optional in `#[table]` macro.

### DIFF
--- a/examples/blog/main.rs
+++ b/examples/blog/main.rs
@@ -2,7 +2,7 @@ use atmosphere::prelude::*;
 use sqlx::types::chrono;
 
 #[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-#[table(schema = "public", name = "user")]
+#[table(name = "user")]
 struct User {
     #[sql(pk)]
     id: i32,
@@ -12,7 +12,7 @@ struct User {
 }
 
 #[derive(Schema, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-#[table(schema = "public", name = "post")]
+#[table(name = "post")]
 struct Post {
     #[sql(pk)]
     id: i32,


### PR DESCRIPTION
This one is more of an idea:

When you don't specify which schema to use, it falls back to using the `public` schema. Likewise, when you don't specify the table name, it will simply use the name of the struct.

## Todo

- `snake_case` the name of the struct?
- pluralize the name of the struct?
- use something like serde's `rename = "UPPER_CASE"` here?
- make the `public` schema string a const?