### PR TITLE
refactor: rename Read trait functions for alignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [".", "atmosphere-core", "atmosphere-macros"]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 license = "Apache-2.0"
 edition = "2021"
 exclude = ["/.github", "/tests"]
@@ -16,8 +16,8 @@ repository = "https://github.com/helsing-ai/atmosphere"
 keywords = ["sqlx", "postgres", "database", "orm", "backend"]
 
 [workspace.dependencies]
-atmosphere-core = { version = "=0.2.0", path = "atmosphere-core" }
-atmosphere-macros = { version = "=0.2.0", path = "atmosphere-macros" }
+atmosphere-core = { version = "=0.3.0", path = "atmosphere-core" }
+atmosphere-macros = { version = "=0.3.0", path = "atmosphere-macros" }
 async-trait = "0.1"
 lazy_static = "1"
 sqlx = { version = "0.7", features = ["chrono"] }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![SQLx](https://img.shields.io/badge/sqlx-framework-blueviolet.svg)](https://github.com/launchbadge/sqlx)
 [![Crate](https://img.shields.io/crates/v/atmosphere.svg)](https://crates.io/crates/atmosphere)
-[![Book](https://img.shields.io/badge/book-latest-0f5225.svg)](https://bmc-labs.github.io/atmosphere)
+[![Book](https://img.shields.io/badge/book-latest-0f5225.svg)](https://helsing-ai.github.io/atmosphere)
 [![Docs](https://img.shields.io/badge/docs-latest-153f66.svg)](https://docs.rs/atmosphere)
 
 </div>
@@ -70,7 +70,7 @@ async fn main() -> sqlx::Result<()> {
     // Field Queries
 
     assert_eq!(
-        User::find(&pool, &0).await?,
+        User::read(&pool, &0).await?,
         User::find_by_email(&pool, "some@email.com").await?.unwrap()
     );
 
@@ -167,14 +167,15 @@ Atmosphere is able to derive and generate the following queries:
 
 #### `atmosphere::Read`
 
-- `Model::find`
-- `Model::find_all`
+- `Model::read`: read a `Model` by its primary key, returning a `Model`.
+- `Model::find`: find a `Model` by its primary key, returning an `Option<Model>`.
+- `Model::read_all`: read all `Model`s, returning a `Vec<Model>`.
 - `Model::reload`
 
 #### `atmosphere::Update`
 
 - `Model::update`
-- `Model::save`
+- `Model::upsert`
 
 #### `atmosphere::Delete`
 
@@ -187,8 +188,8 @@ Each struct field that is marked with `#[sql(unique)]` becomes queryable.
 
 In the above example `b` was marked as unique so atmosphere implements:
 
-- `Model::find_by_b`
-- `Model::delete_by_b`
+- `Model::find_by_b`: find a `Model` by its `b` field, returning an `Option<Model>`.
+- `Model::delete_by_b`: delete a `Model` by its `b` field.
 
 ### Relationships & Inter-Table Queries
 

--- a/atmosphere-core/src/schema/delete.rs
+++ b/atmosphere-core/src/schema/delete.rs
@@ -10,10 +10,10 @@ use sqlx::{database::HasArguments, Database, Executor, IntoArguments};
 
 /// Trait for deleting rows from a database.
 ///
-/// Provides functionality for deleting rows from a table in the database. Implementors of this trait can delete
-/// entities either by their instance or by their primary key. The trait ensures proper execution of hooks at
-/// various stages of the delete operation, enhancing flexibility and allowing for custom behavior during the
-/// deletion process.
+/// Provides functionality for deleting rows from a table in the database. Implementors of this
+/// trait can delete entities either by their instance or by their primary key. The trait ensures
+/// proper execution of hooks at various stages of the delete operation, enhancing flexibility and
+/// allowing for custom behavior during the deletion process.
 #[async_trait]
 pub trait Delete: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     /// Deletes the row represented by the instance from the database. Builds and executes a delete

--- a/atmosphere-core/src/schema/update.rs
+++ b/atmosphere-core/src/schema/update.rs
@@ -10,9 +10,10 @@ use sqlx::{database::HasArguments, Database, Executor, IntoArguments};
 
 /// Update rows in a database.
 ///
-/// Provides functionality for updating data in tables within a SQL database. This trait defines asynchronous methods
-/// for modifying existing rows in the database, either through direct updates or upserts (update or insert if not exists).
-/// It ensures that hooks are executed at various stages, enabling custom logic to be integrated into the update process.
+/// Provides functionality for updating data in tables within a SQL database. This trait defines
+/// asynchronous methods for modifying existing rows in the database, either through direct updates
+/// or upserts (update or insert if not exists). It ensures that hooks are executed at various
+/// stages, enabling custom logic to be integrated into the update process.
 #[async_trait]
 pub trait Update: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
     /// Updates an existing row in the database. This method constructs an update query, binds the
@@ -27,10 +28,9 @@ pub trait Update: Table + Bind + Hooks + Send + Sync + Unpin + 'static {
         for<'q> <crate::Driver as HasArguments<'q>>::Arguments:
             IntoArguments<'q, crate::Driver> + Send;
 
-    /// Similar to `update`, but uses an upsert approach. It either updates an existing row or
-    /// inserts a new one if it does not exist, depending on the primary key's presence and
-    /// uniqueness.
-    async fn save<'e, E>(
+    /// Similar to `update`, but either updates an existing row or inserts a new one if it does not
+    /// exist, depending on the primary key's presence and uniqueness.
+    async fn upsert<'e, E>(
         &mut self,
         executor: E,
     ) -> Result<<crate::Driver as Database>::QueryResult>
@@ -83,7 +83,10 @@ where
         res
     }
 
-    async fn save<'e, E>(&mut self, executor: E) -> Result<<crate::Driver as Database>::QueryResult>
+    async fn upsert<'e, E>(
+        &mut self,
+        executor: E,
+    ) -> Result<<crate::Driver as Database>::QueryResult>
     where
         E: Executor<'e, Database = crate::Driver>,
         for<'q> <crate::Driver as HasArguments<'q>>::Arguments:

--- a/atmosphere-macros/Cargo.toml
+++ b/atmosphere-macros/Cargo.toml
@@ -14,7 +14,10 @@ proc-macro = true
 atmosphere-core.workspace = true
 sqlx.workspace = true
 proc-macro2 = { version = "1.0.36", default-features = false }
-syn = { version = "2.0.39", default-features = false, features = ["parsing", "proc-macro"] }
+syn = { version = "2.0.39", default-features = false, features = [
+    "parsing",
+    "proc-macro",
+] }
 quote = { version = "1.0.14", default-features = false }
 lazy_static = "1.4.0"
 

--- a/atmosphere-macros/src/schema/table.rs
+++ b/atmosphere-macros/src/schema/table.rs
@@ -55,7 +55,12 @@ impl Parse for TableId {
 
 #[derive(Clone, Debug)]
 pub struct Table {
+    // TODO(flrn):
+    //  confirm what the fields `vis` and `generics` were
+    //  intended for; remove them if they are not needed
+    #[allow(dead_code)]
     pub vis: Visibility,
+    #[allow(dead_code)]
     pub generics: Generics,
     pub ident: Ident,
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,5 +1,5 @@
 [book]
-authors = ["Mara Schulke <mara.schulke@bmc-labs.com>"]
+authors = ["Mara Schulke <mara.schulke@helsing.ai>"]
 language = "en"
 multilingual = false
 src = "src"

--- a/docs/src/getting-started/queries.md
+++ b/docs/src/getting-started/queries.md
@@ -50,7 +50,7 @@ user.delete(&pool).await?;
 user.create(&pool).await?;
 
 assert_eq!(
-    User::find(&pool, &0).await?,
+    User::read(&pool, &0).await?,
     User::find_by_email(&pool, &"some@email.com".to_string()).await?.unwrap()
 );
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,5 +15,5 @@ enabling low level usage of the underlying `sqlx` concepts.
 
 **[Traits](traits/index.md)**
 
-[GitHub]: https://github.com/bmc-labs/atmosphere/tree/main
+[GitHub]: https://github.com/helsing-ai/atmosphere/tree/main
 [`sqlx`]: https://github.com/launchbadge/sqlx

--- a/tests/db/crud.rs
+++ b/tests/db/crud.rs
@@ -36,7 +36,7 @@ async fn create(pool: sqlx::PgPool) {
         name: "place".to_owned(),
         location: "holder".to_owned(),
     }
-    .save(&pool)
+    .upsert(&pool)
     .await
     .unwrap();
 
@@ -60,7 +60,7 @@ async fn read(pool: sqlx::PgPool) {
         name: "place".to_owned(),
         location: "holder".to_owned(),
     }
-    .save(&pool)
+    .upsert(&pool)
     .await
     .unwrap();
 
@@ -101,7 +101,7 @@ async fn update(pool: sqlx::PgPool) {
         name: "place".to_owned(),
         location: "holder".to_owned(),
     }
-    .save(&pool)
+    .upsert(&pool)
     .await
     .unwrap();
 
@@ -110,7 +110,7 @@ async fn update(pool: sqlx::PgPool) {
         name: "place".to_owned(),
         location: "holder".to_owned(),
     }
-    .save(&pool)
+    .upsert(&pool)
     .await
     .unwrap();
 
@@ -139,7 +139,7 @@ async fn delete(pool: sqlx::PgPool) {
         name: "place".to_owned(),
         location: "holder".to_owned(),
     }
-    .save(&pool)
+    .upsert(&pool)
     .await
     .unwrap();
 


### PR DESCRIPTION
The CUD subset of the CRUD traits have function names corresponding to their trait names:

- `Create` has `create`
- `Update` has `update`
- `Delete` has `delete` (and `delete_by`)

This PR aligns the function names of the `Read` trait:

- `Read::find` --> `Read::read`
- `Read::find_optional` --> `Read::find` (because it returns an `Option<T>`, it actually **does** have "search"/"find" semantics

It also renames `Update::save` to `Update::upsert`, since the docs for `Update::save` literally said that this function has "upsert semantics".

Happy to discuss all of the above! I'd also be happy with `get` terminology, but in that case it would be cool if we could also rename the trait so there is always an "expectable" relationship between trait name and function names.

(There is also some further cleanup here.)